### PR TITLE
Implements #23 - Ensure if servername config changes that certs are updated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,10 @@ services:
       timeout: 90s
       retries: 3
       start_period: 10s
+    networks:
+      default:
+        aliases:
+          - proxy2.nginx.com
 volumes:
   certs:
   node_dist:

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -35,8 +35,8 @@ http {
     # The full set of configuration variables. These can also be defined in
     # environment variables. Use the same name as below, just UPPER_CASE.
     ## Mandatory Variables
-    js_var $njs_acme_server_names proxy.nginx.com;
-    js_var $njs_acme_account_email test@example.com;
+    js_var $njs_acme_server_names "proxy.nginx.com proxy2.nginx.com";
+    js_var $njs_acme_account_email "test@example.com";
 
     ## Optional Variables
     # js_var $njs_acme_dir /etc/nginx/njs-acme;


### PR DESCRIPTION
### Proposed changes

Recognize if `njs_acme_server_names` no longer matches the stored certificate. If so, request a new cert with the configured names.

Also includes a handful of small changes for DRYing up (e.g. adds `acmeCommonName(r)` and `acmeAltNames(r)` methods), defines some more specific types, renames some variables/methods to be more accurate. Adds a second server name to the example config to demonstrate this clearly. 

These changes ended up making the PR bigger than I expected. Happy to remove the changes to make this one lean.

TODO: Add unit tests when #24 is merged (contains unit test framework improvements).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/njs-acme-experemental/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/njs-acme-experemental/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/njs-acme-experemental/blob/main/CHANGELOG.md))
