### PR TITLE
Added built-in certificates autorenewal

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -9,6 +9,24 @@ events {
 }
 
 http {
+  # Internal upstream for automated certificates renewal
+  upstream acme_auto_renewal {
+    zone acme_auto_renewal 64k;
+    server 127.0.0.1:8000;
+  }
+
+  ## Internal certificates renewal server
+  # GETs 127.0.0.1:8000/acme/auto every 90 seconds to automatically renews certificates
+  server {
+    location /internal_auto_renewal {
+      internal;
+
+      health_check interval=90;
+      health_check uri=/acme/auto;
+      proxy_pass http://acme_auto_renewal;
+    }
+  }
+
   js_path "/usr/lib/nginx/njs_modules/";
   js_fetch_trusted_certificate /etc/ssl/certs/ISRG_Root_X1.pem;
 
@@ -28,7 +46,7 @@ http {
   js_shared_dict_zone zone=acme:1m;
 
   server {
-    listen 0.0.0.0:8000; # testing with 8000 should be 80 in prod, pebble usees httpPort in dev/pebble/config.json
+    listen 0.0.0.0:8000; # testing with 8000 should be 80 in prod, pebble uses httpPort in dev/pebble/config.json
     listen 443 ssl;
     server_name proxy.nginx.com;
 

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -9,21 +9,27 @@ events {
 }
 
 http {
-  # Internal upstream for automated certificates renewal
+  # Internal upstream for automated certificates renewal - Requires NGINX Plus
   upstream acme_auto_renewal {
     zone acme_auto_renewal 64k;
-    server 127.0.0.1:8000;
+    server 127.0.0.1:10080;
   }
 
-  ## Internal certificates renewal server
-  # GETs 127.0.0.1:8000/acme/auto every 90 seconds to automatically renews certificates
+  ## Internal certificates renewal server - Requires NGINX Plus
+  # GETs proxy.nginx.com:8000/acme/auto every 90 seconds to automatically renews certificates
   server {
-    location /internal_auto_renewal {
-      internal;
+    listen 127.0.0.1:10080;
 
+    location / {
+      internal;
       health_check interval=90;
-      health_check uri=/acme/auto;
+      health_check uri=/internal_auto_renewal;
       proxy_pass http://acme_auto_renewal;
+    }
+
+    location = /internal_auto_renewal {
+      proxy_set_header Host proxy.nginx.com;
+      proxy_pass http://127.0.0.1:8000/acme/auto;
     }
   }
 

--- a/examples/nginxplus.conf
+++ b/examples/nginxplus.conf
@@ -9,6 +9,30 @@ events {
 }
 
 http {
+  # Internal upstream for automated certificates renewal - Requires NGINX Plus
+  upstream acme_auto_renewal {
+    zone acme_auto_renewal 64k;
+    server 127.0.0.1:10080;
+  }
+
+  ## Internal certificates renewal server - Requires NGINX Plus
+  # GETs proxy.nginx.com:8000/acme/auto every 90 seconds to automatically renews certificates
+  server {
+    listen 127.0.0.1:10080;
+
+    location / {
+      internal;
+      health_check interval=90;
+      health_check uri=/internal_auto_renewal;
+      proxy_pass http://acme_auto_renewal;
+    }
+
+    location = /internal_auto_renewal {
+      proxy_set_header Host proxy.nginx.com;
+      proxy_pass http://127.0.0.1:8000/acme/auto;
+    }
+  }
+
   js_path "/usr/lib/nginx/njs_modules/";
   js_fetch_trusted_certificate /etc/ssl/certs/ISRG_Root_X1.pem;
 


### PR DESCRIPTION
### Proposed changes

This PR adds automated certificates renewal. Adding one internal `server {}` and `upstream {}` enables a self-contained solution to periodically send `GET` requests to `/acme/auto`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginx/njs-acme/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/njs-acme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/njs-acme/blob/main/CHANGELOG.md))
