### PR TITLE
feat: use the js_periodic directive to check/issue/renew certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
-ARG NGINX_VERSION=1.24.0
+ARG NGINX_VERSION=1.25.3
+ARG NJS_VERSION=0.8.2
 
-FROM node:18 AS builder
+FROM node:20-bullseye AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/app/.npm \
@@ -16,7 +17,7 @@ COPY ./examples/nginx.conf /etc/nginx/nginx.conf
 RUN mkdir /etc/nginx/njs-acme
 RUN chown nginx: /etc/nginx/njs-acme
 
-# install the latest njs > 0.8.0 (not yet bundled with nginx-1.25.1)
+# install the latest njs >= 0.8.1 (not yet bundled with nginx-1.25.2)
 RUN --mount=type=cache,target=/var/cache/apt <<EOF
     set -eux
     export DEBIAN_FRONTEND=noninteractive
@@ -33,7 +34,7 @@ RUN --mount=type=cache,target=/var/cache/apt <<EOF
     | tee /etc/apt/sources.list.d/nginx.list
     apt update -qq
     apt install -qq  --yes --no-install-recommends --no-install-suggests \
-        nginx-module-njs
+        nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE}
     apt remove --purge --auto-remove --yes
     rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG NGINX_VERSION=1.25.3
-ARG NJS_VERSION=0.8.2
 
-FROM node:20-bullseye AS builder
+FROM node:20 AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/app/.npm \
@@ -16,25 +15,3 @@ COPY --from=builder /app/dist/acme.js /usr/lib/nginx/njs_modules/acme.js
 COPY ./examples/nginx.conf /etc/nginx/nginx.conf
 RUN mkdir /etc/nginx/njs-acme
 RUN chown nginx: /etc/nginx/njs-acme
-
-# install the latest njs >= 0.8.1 (not yet bundled with nginx-1.25.2)
-RUN --mount=type=cache,target=/var/cache/apt <<EOF
-    set -eux
-    export DEBIAN_FRONTEND=noninteractive
-    apt -qq update
-    apt install -qq  --yes --no-install-recommends --no-install-suggests \
-        curl gnupg2 ca-certificates lsb-release debian-archive-keyring
-    update-ca-certificates
-    curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
-        | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
-    gpg --dry-run --quiet --no-keyring --import --import-options import-show \
-        /usr/share/keyrings/nginx-archive-keyring.gpg
-    echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-        http://nginx.org/packages/mainline/debian `lsb_release -cs` nginx" \
-    | tee /etc/apt/sources.list.d/nginx.list
-    apt update -qq
-    apt install -qq  --yes --no-install-recommends --no-install-suggests \
-        nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE}
-    apt remove --purge --auto-remove --yes
-    rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list
-EOF

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:
 .PHONY:
 build: ## Run npm run build
 	$Q echo "$(M) building in release mode for the current platform"
-	$Q npm run build
+	$Q npm ci && npm run build
 
 
 .PHONY: docker-build

--- a/README.md
+++ b/README.md
@@ -240,9 +240,10 @@ Choose to "Reopen in container" and the services specified in the `docker-compos
 #### Docker Compose
 
 If you just want to start the development environment using Docker (no devcontainer) then run:
-    ```
-    make docker-devup
-    ```
+```
+make docker-devup
+```
+
 
 ### Without Docker
 

--- a/README.md
+++ b/README.md
@@ -267,29 +267,29 @@ To follow these steps, you will need to have Node.js version 14.15 or greater in
 
 1. Start a test environment in Docker:
 
-        make docker-devup
+       make docker-devup
 
 2. Optionally you can watch for `nginx` log file in a separate shell:
 
-        docker compose logs -f nginx
+       docker compose logs -f nginx
 
 3. When started initially, nginx will not have certificates at all. If you use the [example config](examples/nginx.conf), you will need to wait one minute for the `js_periodic` directive to invoke `acme.clientAutoMode` to create the certificate.
 
 4. Send an HTTP request to nginx running in Docker:
 
-        curl -vik --resolve proxy.nginx.com:8000:127.0.0.1 http://proxy.nginx.com:8000/
+       curl -vik --resolve proxy.nginx.com:8000:127.0.0.1 http://proxy.nginx.com:8000/
 
 5. Send an HTTPS request to nginx running in Docker to test a new certificate:
 
-        curl -vik --resolve proxy.nginx.com:4443:127.0.0.1 https://proxy.nginx.com:4443
+       curl -vik --resolve proxy.nginx.com:4443:127.0.0.1 https://proxy.nginx.com:4443
 
 6. Test with `openssl`:
 
-        openssl s_client -servername proxy.nginx.com -connect localhost:4443 -showcerts
+       openssl s_client -servername proxy.nginx.com -connect localhost:4443 -showcerts
 
 7. Display content of certificates
 
-        docker compose exec -it nginx ls -la /etc/nginx/njs-acme/
+       docker compose exec -it nginx ls -la /etc/nginx/njs-acme/
 
 The [docker-compose](./docker-compose.yml) file uses volumes to persist artifacts (account keys, certificate, keys). Additionally, [letsencrypt/pebble](https://github.com/letsencrypt/pebble) is used for testing in Docker, so you don't need to open up port 80 for challenge validation.
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ request or renew certificates if necessary.
     js_periodic acme.clientAutoMode interval=1m;
   }
   ```
-  NOTE: The `js_periodic` command runs *after* the interval period has elapsed, not at the beginning. If your use case requires immediate certificate provisioning, then use the following `location {}` block to expose the HTTP endpoint `/acme/auto` to kick off the certificate provisioning process.
+  ALTERNATIVE: The `js_periodic` command runs *after* the interval period has elapsed, not at the beginning. If your use case requires immediate certificate provisioning, then use the following `location {}` block **instead** to expose the HTTP endpoint `/acme/auto` to kick off the certificate provisioning process.
   ```nginx
   location = /acme/auto {
     allow 127.0.0.1; # Adjust for your needs
@@ -214,6 +214,8 @@ request or renew certificates if necessary.
     js_content acme.clientAutoModeHTTP;
   }
   ```
+
+  Use one location block or the other.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ NOTE: Some ACME providers have strict rate limits. Please consult with your prov
 ## Installation
 
 There are a few ways of using this repo. You can:
-* build an ACME-enabled docker image to replace your existing NGINX image
+* build an ACME-enabled Docker image to replace your existing NGINX image
 * use Docker to build the `acme.js` file to use with your NGINX installation
 * build `acme.js` using a locally installed Node.js toolkit to use with your NGINX installation
 
 Each option above is detailed in each section below.
 
 ### Creating a Docker Image
-To create an Nginx+NJS+njs-acme docker image, simply run:
+To create an Nginx+NJS+njs-acme Docker image, simply run:
 ```
 % make docker-build
 ...
@@ -34,6 +34,8 @@ To create an Nginx+NJS+njs-acme docker image, simply run:
 This will build an image with a recent version of NGINX, required njs version, and the `acme.js` file installed at `/usr/lib/nginx/njs_modules/`.
 
 The image will be tagged `nginx/nginx-njs-acme`, where you can use it in place of a standard `nginx` image.
+
+When running the container, we advise mounting the `/etc/nginx/njs-acme/` directory in a Docker volume so that the cert/key are retained between deployments of your `nginx` container. The `docker-compose.yml` file in this directory shows an example of doing this using the `certs` volume.
 
 ### Building `acme.js` With Docker
 
@@ -48,7 +50,6 @@ This will build the full image and copy the `acme.js` file to the local `dist/` 
 
 If you have Node.js and NPM installed on your computer, you can run this command to generate `acme.js` directly:
 ```
-npm ci
 make build
 ```
 
@@ -56,7 +57,7 @@ This will generate `dist/acme.js`, where you can then integrate it into your exi
 
 ## Configuration Variables
 
-You can use environment variables _or_ NGINX `js_var` directives to control the behavior of the NJS ACME client.
+You can use environment variables _or_ NGINX `js_var` directives to control the behavior of the `njs-acme`.
 
 In the case where both are defined, environment variables take precedence. Environment variables are in `ALL_CAPS`, whereas the nginx config variable is the same name, just prefixed with a dollar sign and `$lower_case`.
 
@@ -85,39 +86,51 @@ You will need to remove the staging certificate from your NGINX server's filesys
 ### Optional Variables
    - `NJS_ACME_VERIFY_PROVIDER_HTTPS` (env)\
      `$njs_acme_verify_provider_https` (js_var)\
-        Verify the ACME provider certificate when connecting.\
-        value: `false` | `true`\
-        default: `true`
+        Verify the ACME provider certificate when connecting.
+        ```
+        value: false | true
+        default: true
+        ```
 
    - `NJS_ACME_DIRECTORY_URI` (env)\
      `$njs_acme_directory_uri` (js_var)\
-        ACME directory URL.\
-        value: Any valid URL\
-        default: `https://acme-staging-v02.api.letsencrypt.org/directory`
+        ACME directory URL.
+        ```
+        value: {Any valid URL}
+        default: https://acme-staging-v02.api.letsencrypt.org/directory
+        ```
 
    - `NJS_ACME_DIR` (env)\
      `$njs_acme_dir` (js_var)\
-        Path to store ACME-related files such as keys, certificate requests, certificates, etc.\
-        value: Any valid system path writable by the `nginx` user. \
-        default: `/etc/nginx/njs-acme/`
+        Path to store ACME-related files such as keys, certificate requests, certificates, etc.
+        ```
+        value: Any valid system path writable by the `nginx` user.
+        default: /etc/nginx/njs-acme/
+        ```
 
    - `NJS_ACME_CHALLENGE_DIR` (env)\
      `$njs_acme_challenge_dir` (js_var)\
-        Path to store ACME-related challenge responses.\
-        value: Any valid system path writable by the `nginx` user. \
+        Path to store ACME-related challenge responses.
+        ```
+        value: Any valid system path writable by the `nginx` user.
         default: `${NJS_ACME_DIR}/challenge/`
+        ```
 
    - `NJS_ACME_ACCOUNT_PRIVATE_JWK` (env)\
      `$njs_acme_account_private_jwk` (js_var)\
-        Path to fetch/store the account private JWK.\
-        value: Path to the private JWK\
-        default: `${NJS_ACME_DIR}/account_private_key.json`
+        Path to fetch/store the account private JWK.
+        ```
+        value: Path to the private JWK
+        default: ${NJS_ACME_DIR}/account_private_key.json
+        ```
 
    - `NJS_ACME_SHARED_DICT_ZONE_NAME` (env)\
      `$njs_acme_shared_dict_zone_name` (js_var)\
-        [Shared Dictionary Zone](https://nginx.org/en/docs/http/ngx_http_js_module.html#js_shared_dict_zone) name .\
-        value: Zone name used as in `js_shared_dict_zone` directive\
-        default: `acme`
+        [Shared Dictionary Zone](https://nginx.org/en/docs/http/ngx_http_js_module.html#js_shared_dict_zone) name .
+        ```
+        value: Zone name used as in `js_shared_dict_zone` directive
+        default: acme`
+        ```
 
 ## NGINX Configuration
 
@@ -203,27 +216,35 @@ The ACME RESTful client is implemented using [ngx.fetch](http://nginx.org/en/doc
 
 There is a `docker-compose.yml` file in the project root directory that brings up an ACME server, a challenge server, a Node.js container for rebuilding the `acme.js` file when source files change, and an NGINX container. The built `acme.js` file is shared between the Node.js and NGINX containers. The NGINX container will reload when the `acme.js` file changes.
 
-To start up the development environment with docker compose, run the following:
-
-    make docker-devup
+#### VSCode Devcontainer
 
 If you use VSCode or another devcontainer-compatible editor, then run the following:
-
-    code .
+```
+code .
+```
 
 Choose to "Reopen in container" and the services specified in the `docker-compose.yml` file will start. Editing and saving source files will trigger a rebuild of the `acme.js` file, and NGINX will reload its configuration.
+
+#### Docker Compose
+
+If you just want to start the development environment using Docker (no devcontainer) then run:
+    ```
+    make docker-devup
+    ```
 
 ### Without Docker
 
 To follow these steps, you will need to have Node.js version 14.15 or greater installed on your system.
 
 1. Install dependencies:
-
-        npm ci
+    ```
+    npm ci
+    ```
 
 2. Start the watcher:
-
-        npm run watch
+    ```
+    npm run watch
+    ```
 
 3. Edit the source files. When you save a change, the watcher will rebuild `./dist/acme.js` or display errors.
 
@@ -265,7 +286,7 @@ The [docker-compose](./docker-compose.yml) file uses volumes to persist artifact
 
 If the reference implementation does not meet your needs, then you can build your own flows using this project as a library of convenience functions.
 
-Look at `clientAutoMode` in [`src/index.ts`](./src/index.ts) to see how you can use the convenience functions to build a ACME client implementation.
+Look at `clientAutoMode` in [`src/index.ts`](./src/index.ts) to see how you can use the convenience functions to build a ACME client implementation. There are some additional methods in [`src/examples.ts`](./src/examples.ts) showing how to use the ACME account creation APIs or generating Certificate Signing Requests on demand.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ For example, `NJS_ACME_SERVER_NAMES` (env var) is the same as `$njs_acme_server_
 
 There are a few pieces that are required to be present in your `nginx.conf` file. The file at [`examples/nginx.conf`](./examples/nginx.conf) shows them all.
 
-The examples here use `js_var` for configuration variables, but keep in mind you can use the equivalent environment variables instead if that works better in your environment.
+NOTE: The examples here use `js_var` for configuration variables, but keep in mind you can use the equivalent environment variables instead if that works better in your environment. See the Configuration Variables section above for specifics.
 
-### Config Root
+### `nginx.conf` Root
 * Ensures the NJS module is loaded.
    ```nginx
   load_module modules/ngx_http_js_module.so;
@@ -147,7 +147,7 @@ The examples here use `js_var` for configuration variables, but keep in mind you
   ```nginx
   js_shared_dict_zone zone=acme:1m
   ```
-  * NOTE: If you want to use a different `js_shared_dict_zone` name, then you need to define the variable `$njs_acme_shared_dict_zone_name` with the name you would like to use.
+  * NOTE: If you want to use a different `js_shared_dict_zone` name, then you need to define the variable `$njs_acme_shared_dict_zone_name` with the name you would like to use. You can also use the environment variable `NJS_ACME_SHARED_DICT_ZONE_NAME`.
     ```nginx
     js_var $njs_acme_shared_dict_zone_name acme;
     ```
@@ -173,7 +173,7 @@ This may also be defined with the environment variable `NJS_ACME_SERVER_NAMES`.
   ```
 
 ### `location` Blocks
-* Location to handle ACME challenge requests. This must be accessible from the ACME server.
+* Location to handle ACME challenge requests. This must be accessible from the ACME server - in most cases this means accessbile from another host on the Internet if you are using a service like Let's Encrypt.
   ```nginx
   location ~ "^/\.well-known/acme-challenge/[-_A-Za-z0-9]{22,128}$" {
     js_content acme.challengeResponse;

--- a/README.md
+++ b/README.md
@@ -198,14 +198,15 @@ This may also be defined with the environment variable `NJS_ACME_SERVER_NAMES`.
     js_content acme.challengeResponse;
   }
   ```
-* Named location to contain the `js_periodic` directive to automatically
-request or renew certificates if necessary.
+* Named location to contain the `js_periodic` directive to automatically request or renew certificates if necessary.
+
+  > NOTE: This runs at the *end* of each interval, so your server will not be ready for a minute. If this is a problem for your use case, see the ALTERNATIVE below.
   ```nginx
   location @acmePeriodicAuto {
     js_periodic acme.clientAutoMode interval=1m;
   }
   ```
-  ALTERNATIVE: The `js_periodic` command runs *after* the interval period has elapsed, not at the beginning. If your use case requires immediate certificate provisioning, then use the following `location {}` block **instead** to expose the HTTP endpoint `/acme/auto` to kick off the certificate provisioning process.
+  ALTERNATIVE: The `js_periodic` command runs *after* the interval period has elapsed, not at the beginning. If your use case requires immediate certificate provisioning, then use the following `location {}` block **instead**. This location exposes the endpoint `/acme/auto`, which triggers the certificate provisioning process when requested.
   ```nginx
   location = /acme/auto {
     allow 127.0.0.1; # Adjust for your needs

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ In the case where both are defined, environment variables take precedence. Envir
 
 For example, `NJS_ACME_SERVER_NAMES` (env var) is the same as `$njs_acme_server_names` (js_var).
 
+### Staging by Default
+
+The value of the variable `NJS_ACME_DIRECTORY_URI` (`js_var $njs_acme_directory_uri`) defaults to Let's Encrypt's _Staging_ environment. When you are finished testing with their staging environment, you will need to define/change the value of this to your ACME provider's production environment. In Let's Encrypt's case the production URL is `https://acme-v02.api.letsencrypt.org/directory`.
+
+You will need to remove the staging certificate from your NGINX server's filesystem when changing from staging to production. It is located in `/etc/nginx/njs-acme/` by default (controlled by the variable `NJS_ACME_DIR`).
+
 ### Required Variables
 
    - `NJS_ACME_ACCOUNT_EMAIL` (env)\

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ There are a few pieces that are required to be present in your `nginx.conf` file
     js_var $njs_acme_shared_dict_zone_name acme;
     ```
 
-### `server` Section
+### `server` Section(s)
 * Set your email address to use to configure your ACME account. This may also
 be defined with the environment variable `NJS_ACME_ACCOUNT_EMAIL`.
   ```nginx
@@ -164,16 +164,11 @@ This may also be defined with the environment variable `NJS_ACME_SERVER_NAMES`.
     js_content acme.challengeResponse;
   }
   ```
-* Locations to trigger and handle requests to automatically request or renew certificates if necessary.
+* Named location to contain the `js_periodic` directive to automatically
+request or renew certificates if necessary.
   ```nginx
   location @acmePeriodicAuto {
-    js_periodic acme.periodicAuto interval=1m;
-  }
-  location = /acme/auto {
-    js_content acme.clientAutoMode;
-    # Make sure you are not exposing this location to the Internet.
-    allow 127.0.0.1;
-    deny all;
+    js_periodic acme.clientAutoMode interval=1m;
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,15 @@ request or renew certificates if necessary.
     js_periodic acme.clientAutoMode interval=1m;
   }
   ```
+  NOTE: The `js_periodic` command runs *after* the interval period has elapsed, not at the beginning. If your use case requires immediate certificate provisioning, then use the following `location {}` block to expose the HTTP endpoint `/acme/auto` to kick off the certificate provisioning process.
+  ```nginx
+  location = /acme/auto {
+    allow 127.0.0.1; # Adjust for your needs
+    deny all;
+    js_periodic acme.clientAutoMode interval=1m;
+    js_content acme.clientAutoModeHTTP;
+  }
+  ```
 
 ## Development
 

--- a/dev/Dockerfile.nginx
+++ b/dev/Dockerfile.nginx
@@ -1,8 +1,6 @@
-ARG NGINX_VERSION=1.25.2
-ARG NJS_VERSION=0.8.1
+ARG NGINX_VERSION=1.25.3
 FROM nginx:${NGINX_VERSION}
 ARG NGINX_VERSION
-ARG NJS_VERSION
 
 RUN --mount=type=cache,target=/var/cache/apt <<EOF
     set -eux
@@ -12,29 +10,6 @@ RUN --mount=type=cache,target=/var/cache/apt <<EOF
         curl gnupg2 ca-certificates debian-archive-keyring inotify-tools
     update-ca-certificates
     apt-get remove --purge --auto-remove --yes
-EOF
-
-RUN echo nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE}
-
-# As of 09/28/2023 NJS v0.8.1 is not included into nginx docker image.
-# this a temprary patch to install it following installation steps from
-# http://nginx.org/en/linux_packages.html#Debian
-RUN --mount=type=cache,target=/var/cache/apt <<EOF
-    set -eux
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get -qq update
-    curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
-        | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
-    gpg --dry-run --quiet --no-keyring --import --import-options import-show \
-        /usr/share/keyrings/nginx-archive-keyring.gpg
-    echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-        http://nginx.org/packages/mainline/debian $(echo $PKG_RELEASE | cut -f2 -d~) nginx" \
-        | tee /etc/apt/sources.list.d/nginx.list
-    apt-get -qq update
-    apt-get -qq install --yes --no-install-recommends --no-install-suggests \
-        nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE}
-    apt-get remove --purge --auto-remove --yes
-    rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list
 EOF
 
 RUN mkdir -p /usr/lib/nginx/njs_modules

--- a/dev/Dockerfile.nginx
+++ b/dev/Dockerfile.nginx
@@ -1,5 +1,5 @@
-ARG NGINX_VERSION=1.25.1
-ARG NJS_VERSION=0.8.0
+ARG NGINX_VERSION=1.25.2
+ARG NJS_VERSION=0.8.1
 FROM nginx:${NGINX_VERSION}
 ARG NGINX_VERSION
 ARG NJS_VERSION
@@ -14,9 +14,11 @@ RUN --mount=type=cache,target=/var/cache/apt <<EOF
     apt-get remove --purge --auto-remove --yes
 EOF
 
-# As of 07/13/2023 NJS v0.8.0 is not included into nginx docker image.
-# this a temprary to install it
-# following installation steps from http://nginx.org/en/linux_packages.html#Debian
+RUN echo nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE}
+
+# As of 09/28/2023 NJS v0.8.1 is not included into nginx docker image.
+# this a temprary patch to install it following installation steps from
+# http://nginx.org/en/linux_packages.html#Debian
 RUN --mount=type=cache,target=/var/cache/apt <<EOF
     set -eux
     export DEBIAN_FRONTEND=noninteractive

--- a/dev/nginx_wait_for_js
+++ b/dev/nginx_wait_for_js
@@ -20,5 +20,5 @@ echo "Watching for changes..."
 inotifywait -m -e create,modify $JS_FILE |
   while read filename
   do
-    nginx -s reload
+    $1 -s reload
   done

--- a/dev/pebble/config.json
+++ b/dev/pebble/config.json
@@ -4,7 +4,7 @@
       "managementListenAddress": "0.0.0.0:15000",
       "certificate": "/etc/pebble/cert.pem",
       "privateKey": "/etc/pebble/key.pem",
-      "httpPort": 8000,
+      "httpPort": 80,
       "tlsPort": 5001,
       "ocspResponderURL": "",
       "externalAccountBindingRequired": false,

--- a/dev/pebble/config.json
+++ b/dev/pebble/config.json
@@ -4,7 +4,7 @@
       "managementListenAddress": "0.0.0.0:15000",
       "certificate": "/etc/pebble/cert.pem",
       "privateKey": "/etc/pebble/key.pem",
-      "httpPort": 80,
+      "httpPort": 8000,
       "tlsPort": 5001,
       "ocspResponderURL": "",
       "externalAccountBindingRequired": false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - NJS_ACME_VERIFY_PROVIDER_HTTPS=false # only in development environment
       - NJS_ACME_DIRECTORY_URI=https://pebble/dir # development server
     ports:
-      - 8000:80
-      - 4443:443
+      - 8000:8000
+      - 4443:4443
     networks:
       default:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,19 +37,11 @@ services:
       - node_dist:/usr/lib/nginx/njs_modules/
       - certs:/etc/nginx/njs-acme/
     environment:
-      - NJS_ACME_DIR=/etc/nginx/njs-acme/
-      - NJS_ACME_VERIFY_PROVIDER_HTTPS=false
-      - NJS_ACME_DIRECTORY_URI=https://pebble/dir
-      - NJS_ACME_ACCOUNT_EMAIL=test@example.com
+      - NJS_ACME_VERIFY_PROVIDER_HTTPS=false # only in development environment
+      - NJS_ACME_DIRECTORY_URI=https://pebble/dir # development server
     ports:
-      - 8000:8000
+      - 8000:80
       - 4443:443
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://proxy.nginx.com:8000/acme/auto"]
-      interval: 90s
-      timeout: 90s
-      retries: 3
-      start_period: 10s
     networks:
       default:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - NJS_ACME_VERIFY_PROVIDER_HTTPS=false # only in development environment
       - NJS_ACME_DIRECTORY_URI=https://pebble/dir # development server
     ports:
-      - 8000:8000
-      - 4443:4443
+      - 8000:80
+      - 4443:443
     networks:
       default:
         aliases:

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -69,8 +69,13 @@ http {
     ssl_certificate data:$dynamic_ssl_cert;
     ssl_certificate_key data:$dynamic_ssl_key;
 
-    # Check certificate validity each minute
+    # `js_periodic` must be in a location {} block, so use a named location to
+    # avoid affecting URI space.
+    # From https://nginx.org/en/docs/http/ngx_http_core_module.html#location
+    #   The “@” prefix defines a named location. Such a location is not used for a
+    #   regular request processing, but instead used for request redirection.
     location @acmePeriodicAuto {
+      # Check certificate validity each minute
       js_periodic acme.clientAutoMode interval=1m;
     }
 

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -12,9 +12,10 @@ http {
   js_path "/usr/lib/nginx/njs_modules/";
   js_fetch_trusted_certificate /etc/ssl/certs/ISRG_Root_X1.pem;
 
+  # Read the .js file into the `acme` namespace.
   js_import acme from acme.js;
 
-  # One `resolver` directive must be defined.
+  # IMPORTANT: One `resolver` directive *must* be defined.
   resolver 127.0.0.11 ipv6=off; # docker-compose
   # resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001] valid=300s; # Cloudflare
   # resolver 8.8.8.8 8.8.4.4; # Google
@@ -22,57 +23,81 @@ http {
   # resolver 169.254.169.253; # AWS VPC
   resolver_timeout 5s;
 
-  ## advanced use-case for njs-acme to optionally use shared dict to cache cert/key pairs
-  # then provide the same zone name in $njs_acme_shared_dict_zone_name
-  # zone size should be enough to store all certs and keys; 1MB should be enough to store 100 certs/keys
+  ##
+  # `njs-acme` can use a shared dict to cache cert/key pairs to avoid
+  # filesystem calls on TLS handshake.  If you want to use a shared zone name
+  # that is not `acme`, then ensure the variable $njs_acme_shared_dict_zone_name
+  # also contains the desired name.  The zone size should beenough to store all
+  # certs and keys. 1MB should be enough to store 100 certs/keys.
   js_shared_dict_zone zone=acme:1m;
 
   server {
-    listen 0.0.0.0:8000; # testing with 8000 should be 80 in prod, pebble usees httpPort in dev/pebble/config.json
+    listen 80;
     listen 443 ssl;
-    server_name proxy.nginx.com;
+    server_name _default;
 
-    # The full set of configuration variables. These can also be defined in
-    # environment variables. Use the same name as below, just UPPER_CASE.
     ## Mandatory Variables
-    js_var $njs_acme_server_names "proxy.nginx.com proxy2.nginx.com";
-    js_var $njs_acme_account_email "test@example.com";
+    # These, and other variables, may also be defined in
+    # environment variables, just without the leading dollar sign and with the
+    # variable name in upper case, e.g.  `NJS_ACME_SERVER_NAMES`.
+    js_var $njs_acme_server_names 'proxy.nginx.com proxy2.nginx.com';
+    js_var $njs_acme_account_email 'test@example.com';
 
-    ## Optional Variables
+    ## Optional Variables and their defaults.
     # js_var $njs_acme_dir /etc/nginx/njs-acme;
     # js_var $njs_acme_challenge_dir /etc/nginx/njs-acme/challenge;
     # js_var $njs_acme_account_private_jwk /etc/nginx/njs-acme/account_private_key.json;
-    # js_var $njs_acme_directory_uri https://pebble/dir;
-    # js_var $njs_acme_verify_provider_https false;
+    # js_var $njs_acme_directory_uri https://acme-staging-v02.api.letsencrypt.org/directory;
+    # js_var $njs_acme_verify_provider_https true;
+    # js_var $njs_acme_shared_dict_zone_name acme;
 
-    ## advanced use-case
-    # # use a `js_shared_dict_zone` to store certs/keys in memory
-    js_var $njs_acme_shared_dict_zone_name acme;
+    # Use a `js_shared_dict_zone` to store certs/keys in memory to minimize
+    # filesystem calls.
 
+    # Stores the key/cert content in these variables.
     js_set $dynamic_ssl_cert acme.js_cert;
     js_set $dynamic_ssl_key acme.js_key;
 
-
-
+    # Uses the key/cert stored in variables for HTTPS
     ssl_certificate data:$dynamic_ssl_cert;
     ssl_certificate_key data:$dynamic_ssl_key;
 
-    location = / {
-      return 200 "hello server_name:$server_name\nssl_session_id:$ssl_session_id\n";
-    }
-
+    # Respond to ACME challenges
     location ~ "^/\.well-known/acme-challenge/[-_A-Za-z0-9]{22,128}$" {
       js_content acme.challengeResponse;
     }
 
+    # Check for certificate expiration every minute
+    location @acmePeriodicAuto {
+      js_periodic acme.periodicAuto interval=1m;
+    }
+
+    # Endpoint called by `acme.periodicAuto` that checks for cert expiration.
     location = /acme/auto {
+      allow 127.0.0.1;
+      deny all;
       js_content acme.clientAutoMode;
     }
 
+    # Your location(s) go here
+    location = / {
+      return 200 "hello server_name:$server_name\nssl_session_id:$ssl_session_id\n";
+    }
+
+    ## ADVANCED USAGE BELOW
+    # You can define your own workflows using njs-acme as an ACME client
+    # library if the /acme/auto handler does not meet your needs. Here are two
+    # examples of endpoints mapped to granular steps in the request/renewal
+    # process.
+
+    # Optional endpoint to create a certificate request
+    # (handled automatically in /acme/auto)
     location = /csr/new {
       js_content acme.createCsrHandler;
     }
 
+    # Optional endpoint to create an ACME account
+    # (handled automatically in /acme/auto)
     location = /acme/new-acct {
       js_content acme.acmeNewAccount;
     }

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -31,8 +31,18 @@ http {
   # certs and keys. 1MB should be enough to store 100 certs/keys.
   js_shared_dict_zone zone=acme:1m;
 
+  ##
+  # Set up a specific server to listen on the localhost interface for
+  # js_periodic to trigger acme.clientAutoMode. The default URL is
+  # http://localhost:10999/acme/auto but can be overriden via the
+  # NJS_ACME_CLIENT_AUTO_MODE_URL environment variable.
   server {
     listen 127.0.0.1:10999;
+    # Check for certificate expiration every minute
+    location @acmePeriodicAuto {
+      js_periodic acme.periodicAuto interval=1m;
+    }
+
     location = /acme/auto {
       js_content acme.clientAutoMode;
     }
@@ -70,11 +80,6 @@ http {
     # Respond to ACME challenges
     location ~ "^/\.well-known/acme-challenge/[-_A-Za-z0-9]{22,128}$" {
       js_content acme.challengeResponse;
-    }
-
-    # Check for certificate expiration every minute
-    location @acmePeriodicAuto {
-      js_periodic acme.periodicAuto interval=1m;
     }
 
     # Your location(s) go here

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -32,8 +32,8 @@ http {
   js_shared_dict_zone zone=acme:1m;
 
   server {
-    listen 80;
-    listen 443 ssl;
+    listen 8000;
+    listen 4443 ssl;
     server_name _default;
 
     ## Mandatory Variables
@@ -73,24 +73,6 @@ http {
     # Your location(s) go here
     location = / {
       return 200 "hello server_name:$server_name\nssl_session_id:$ssl_session_id\n";
-    }
-
-    ## ADVANCED USAGE BELOW
-    # You can define your own workflows using njs-acme as an ACME client
-    # library if the /acme/auto handler does not meet your needs. Here are two
-    # examples of endpoints mapped to granular steps in the request/renewal
-    # process.
-
-    # Optional endpoint to create a certificate request
-    # (handled automatically in /acme/auto)
-    location = /csr/new {
-      js_content acme.createCsrHandler;
-    }
-
-    # Optional endpoint to create an ACME account
-    # (handled automatically in /acme/auto)
-    location = /acme/new-acct {
-      js_content acme.acmeNewAccount;
     }
   }
 }

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -32,6 +32,13 @@ http {
   js_shared_dict_zone zone=acme:1m;
 
   server {
+    listen 127.0.0.1:10999;
+    location = /acme/auto {
+      js_content acme.clientAutoMode;
+    }
+  }
+
+  server {
     listen 80;
     listen 443 ssl;
     server_name _default;
@@ -68,13 +75,6 @@ http {
     # Check for certificate expiration every minute
     location @acmePeriodicAuto {
       js_periodic acme.periodicAuto interval=1m;
-    }
-
-    # Endpoint called by `acme.periodicAuto` that checks for cert expiration.
-    location = /acme/auto {
-      allow 127.0.0.1;
-      deny all;
-      js_content acme.clientAutoMode;
     }
 
     # Your location(s) go here

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -1,3 +1,9 @@
+##
+# Example configuration showing a single server block to handle HTTP and HTTP
+# communications, as well as automatcally issuing / renewing the TLS
+# certificate. See the other files in this directory for other examples.
+##
+
 daemon off;
 user nginx;
 
@@ -52,6 +58,9 @@ http {
     # js_var $njs_acme_shared_dict_zone_name acme;
 
 
+    ## Let's Encrypt Production URL (uncomment after you are done testing with their staging environment)
+    # js_var $njs_acme_directory_uri https://acme-v02.api.letsencrypt.org/directory
+
     # Stores the key/cert content in these variables.
     js_set $dynamic_ssl_cert acme.js_cert;
     js_set $dynamic_ssl_key acme.js_key;
@@ -65,7 +74,7 @@ http {
       js_periodic acme.clientAutoMode interval=1m;
     }
 
-    # Respond to ACME challenges
+    # Respond challenges from the ACME server (e.g. Let's Encrypt)
     location ~ "^/\.well-known/acme-challenge/[-_A-Za-z0-9]{22,128}$" {
       js_content acme.challengeResponse;
     }

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -39,7 +39,7 @@ http {
     ## Mandatory Variables
     # These, and other variables, may also be defined in
     # environment variables, just without the leading dollar sign and with the
-    # variable name in upper case, e.g.  `NJS_ACME_SERVER_NAMES`.
+    # variable name in upper case, e.g. `NJS_ACME_SERVER_NAMES`.
     js_var $njs_acme_server_names 'proxy.nginx.com proxy2.nginx.com';
     js_var $njs_acme_account_email 'test@example.com';
 

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -51,8 +51,6 @@ http {
     # js_var $njs_acme_verify_provider_https true;
     # js_var $njs_acme_shared_dict_zone_name acme;
 
-    # Use a `js_shared_dict_zone` to store certs/keys in memory to minimize
-    # filesystem calls.
 
     # Stores the key/cert content in these variables.
     js_set $dynamic_ssl_cert acme.js_cert;

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -32,8 +32,8 @@ http {
   js_shared_dict_zone zone=acme:1m;
 
   server {
-    listen 8000;
-    listen 4443 ssl;
+    listen 80;
+    listen 443 ssl;
     server_name _default;
 
     ## Mandatory Variables

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -27,7 +27,7 @@ http {
   # `njs-acme` can use a shared dict to cache cert/key pairs to avoid
   # filesystem calls on TLS handshake.  If you want to use a shared zone name
   # that is not `acme`, then ensure the variable $njs_acme_shared_dict_zone_name
-  # also contains the desired name.  The zone size should beenough to store all
+  # also contains the desired name.  The zone size should be enough to store all
   # certs and keys. 1MB should be enough to store 100 certs/keys.
   js_shared_dict_zone zone=acme:1m;
 

--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -31,23 +31,6 @@ http {
   # certs and keys. 1MB should be enough to store 100 certs/keys.
   js_shared_dict_zone zone=acme:1m;
 
-  ##
-  # Set up a specific server to listen on the localhost interface for
-  # js_periodic to trigger acme.clientAutoMode. The default URL is
-  # http://localhost:10999/acme/auto but can be overriden via the
-  # NJS_ACME_CLIENT_AUTO_MODE_URL environment variable.
-  server {
-    listen 127.0.0.1:10999;
-    # Check for certificate expiration every minute
-    location @acmePeriodicAuto {
-      js_periodic acme.periodicAuto interval=1m;
-    }
-
-    location = /acme/auto {
-      js_content acme.clientAutoMode;
-    }
-  }
-
   server {
     listen 80;
     listen 443 ssl;
@@ -76,6 +59,11 @@ http {
     # Uses the key/cert stored in variables for HTTPS
     ssl_certificate data:$dynamic_ssl_cert;
     ssl_certificate_key data:$dynamic_ssl_key;
+
+    # Check certificate validity each minute
+    location @acmePeriodicAuto {
+      js_periodic acme.clientAutoMode interval=1m;
+    }
 
     # Respond to ACME challenges
     location ~ "^/\.well-known/acme-challenge/[-_A-Za-z0-9]{22,128}$" {

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,9 +1,14 @@
 # syntax=docker/dockerfile:1
 FROM node:20-bullseye
 
+ARG NGINX_VERSION=1.25.3
+ARG NJS_VERSION=0.8.2
+
 ENV NJS_ACME_DIR=/etc/nginx/njs-acme/
 
-# installing nginx and njs so we can use it while running tests
+RUN env
+
+# install nginx and njs
 RUN --mount=type=cache,target=/var/cache/apt <<EOF
     set -eux
     export DEBIAN_FRONTEND=noninteractive
@@ -20,7 +25,8 @@ RUN --mount=type=cache,target=/var/cache/apt <<EOF
     | tee /etc/apt/sources.list.d/nginx.list
     apt update -qq
     apt install -qq  --yes --no-install-recommends --no-install-suggests \
-        nginx nginx-module-njs
+        nginx=${NGINX_VERSION}-1~bullseye \
+        nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-1~bullseye
     apt remove --purge --auto-remove --yes
     rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list
 EOF

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,12 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM node:20-bullseye
 
-ARG NGINX_VERSION=1.25.3
-ARG NJS_VERSION=0.8.2
-
 ENV NJS_ACME_DIR=/etc/nginx/njs-acme/
-
-RUN env
 
 # install nginx and njs
 RUN --mount=type=cache,target=/var/cache/apt <<EOF
@@ -25,8 +20,7 @@ RUN --mount=type=cache,target=/var/cache/apt <<EOF
     | tee /etc/apt/sources.list.d/nginx.list
     apt update -qq
     apt install -qq  --yes --no-install-recommends --no-install-suggests \
-        nginx=${NGINX_VERSION}-1~bullseye \
-        nginx-module-njs=${NGINX_VERSION}+${NJS_VERSION}-1~bullseye
+        nginx nginx-module-njs
     apt remove --purge --auto-remove --yes
     rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list
 EOF

--- a/integration-tests/acme-auto.test.ts
+++ b/integration-tests/acme-auto.test.ts
@@ -32,7 +32,7 @@ describe('Integration:AutoMode', async function () {
       certInfo.certificate.domains.commonName.includes('Pebble Intermediate CA')
     )
     assert.equal(certInfo.certificate.domains.altNames.length, 1)
-    assert.equal(certInfo.certificate.domains.altNames[0][0], this.nginxHost)
+    assert.equal(certInfo.certificate.domains.altNames[0], this.nginxHost)
 
     const httpsClient = this.client.extend({
       prefixUrl: `https://${this.nginxHost}:${this.nginx.ports[1]}`,

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -1,3 +1,4 @@
+name: njs_acme_integration
 services:
   pebble:
     # image: letsencrypt/pebble:latest
@@ -38,7 +39,7 @@ services:
       - USE_NGINX_BIN_PATH=/usr/sbin/nginx
       - NGINX_HOSTNAME=proxy.nginx.com
     ports:
-      - 8000:8000
-      - 4443:4443
+      - 8000
+      - 4443
 volumes:
   certs:

--- a/integration-tests/nginx.conf
+++ b/integration-tests/nginx.conf
@@ -45,7 +45,7 @@ http {
     }
 
     location = /acme/auto {
-      js_content acme.clientAutoModeWeb;
+      js_content acme.clientAutoModeHTTP;
     }
 
     location = / {

--- a/integration-tests/nginx.conf
+++ b/integration-tests/nginx.conf
@@ -23,7 +23,7 @@ http {
     # pebble usees 8000 as `httpPort` in dev/pebble/config.json so it can validate challebges
     # and nginx must use the same
     listen 0.0.0.0:__PORT__;
-    listen __PORT_1__ ssl http2;
+    listen __PORT_1__ ssl;
     server_name __ADDRESS__;
 
     js_var $njs_acme_server_names __ADDRESS__;
@@ -36,8 +36,8 @@ http {
     ssl_certificate data:$dynamic_ssl_cert;
     ssl_certificate_key data:$dynamic_ssl_key;
 
-    location = / {
-      return 200 '{"server_name":"$server_name", "ssl_session_id": "$ssl_session_id"}';
+    location = /health {
+      return 200 'OK';
     }
 
     location ~ "^/\.well-known/acme-challenge/[-_A-Za-z0-9]{22,128}$" {
@@ -45,7 +45,11 @@ http {
     }
 
     location = /acme/auto {
-      js_content acme.clientAutoMode;
+      js_content acme.clientAutoModeWeb;
+    }
+
+    location = / {
+      return 200 '{"server_name":"$server_name","ssl_session_id":"$ssl_session_id"}';
     }
 
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "mocha": "^10.2.0",
         "mocha-suite-hooks": "^0.1.0",
         "nginx-testing": "^0.4.0",
-        "njs-types": "^0.8.0",
+        "njs-types": "^0.8.2",
         "npm-run-all": "^4.1.5",
         "power-assert": "^1.6.1",
         "prettier": "^2.8.8",
@@ -4538,9 +4538,9 @@
       "dev": true
     },
     "node_modules/njs-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/njs-types/-/njs-types-0.8.0.tgz",
-      "integrity": "sha512-txbfYbBNW+j6qw4NHMBh7luvpgNFjl3RGHtoaYFYajWpN4fehTnoHk9iE5fIuYFfiohYI42Xiy5A7gmvvvpg6A==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/njs-types/-/njs-types-0.8.2.tgz",
+      "integrity": "sha512-6uv1Tcb4khW45LHZqj5vu1uo7WbvB6nINZjDVmryOxiO3K7rDMqRVNJbYtLHOKNbGDqLygIip9iYZbFViIVGqA==",
       "dev": true
     },
     "node_modules/node-fetch": {
@@ -9779,9 +9779,9 @@
       "dev": true
     },
     "njs-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/njs-types/-/njs-types-0.8.0.tgz",
-      "integrity": "sha512-txbfYbBNW+j6qw4NHMBh7luvpgNFjl3RGHtoaYFYajWpN4fehTnoHk9iE5fIuYFfiohYI42Xiy5A7gmvvvpg6A==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/njs-types/-/njs-types-0.8.2.tgz",
+      "integrity": "sha512-6uv1Tcb4khW45LHZqj5vu1uo7WbvB6nINZjDVmryOxiO3K7rDMqRVNJbYtLHOKNbGDqLygIip9iYZbFViIVGqA==",
       "dev": true
     },
     "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "mocha": "^10.2.0",
     "mocha-suite-hooks": "^0.1.0",
     "nginx-testing": "^0.4.0",
-    "njs-types": "^0.8.0",
+    "njs-types": "^0.8.2",
     "npm-run-all": "^4.1.5",
     "power-assert": "^1.6.1",
     "prettier": "^2.8.8",

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -1,0 +1,120 @@
+/**
+ * ADDITIONAL EXAMPLES - Not required for the baseline implementation in
+ * `index.ts` but may be interesting to people who want to create their own
+ * implementations that may facilitate account creation or CSR generation.
+ */
+
+import { HttpClient } from './api'
+import { LogLevel, Logger } from './logger'
+import {
+  acmeAccountPrivateJWKPath,
+  acmeDirectoryURI,
+  acmeVerifyProviderHTTPS,
+  createCsr,
+  generateKey,
+  readOrCreateAccountKey,
+  toPEM,
+} from './utils'
+import { AcmeClient } from './client'
+
+const log = new Logger()
+
+/**
+ * Demonstrates how to use generate RSA Keys and use HttpClient
+ * @param r
+ * @returns
+ */
+async function acmeNewAccount(r: NginxHTTPRequest): Promise<void> {
+  // Generate a new RSA key pair for ACME account
+  const keys = (await generateKey()) as Required<CryptoKeyPair>
+
+  // Create a new ACME account
+  const client = new HttpClient(acmeDirectoryURI(r), keys.privateKey)
+
+  client.minLevel = LogLevel.Debug
+  client.setVerify(acmeVerifyProviderHTTPS(r))
+
+  // Get Terms Of Service link from the ACME provider
+  const tos = await client.getMetaField('termsOfService')
+  log.info(`termsOfService: ${tos}`)
+  // obtain a resource URL
+  const resourceUrl: string = await client.getResourceUrl('newAccount')
+  const payload = {
+    termsOfServiceAgreed: true,
+    contact: ['mailto:test@example.com'],
+  }
+  // Send a signed request
+  const sresp = await client.signedRequest(resourceUrl, payload)
+
+  const respO = {
+    headers: sresp.headers,
+    data: await sresp.json(),
+    status: sresp.status,
+  }
+  return r.return(200, JSON.stringify(respO))
+}
+
+/**
+ * Using AcmeClient to create a new account. It creates an account key if it doesn't exist
+ * @param {NginxHTTPRequest} r Incoming request
+ * @returns void
+ */
+async function clientNewAccount(r: NginxHTTPRequest): Promise<void> {
+  const accountKey = await readOrCreateAccountKey(acmeAccountPrivateJWKPath(r))
+  // Create a new ACME account
+  const client = new AcmeClient({
+    directoryUrl: acmeDirectoryURI(r),
+    accountKey: accountKey,
+  })
+  // display more logs
+  client.api.minLevel = LogLevel.Debug
+  // conditionally validate ACME provider cert
+  client.api.setVerify(acmeVerifyProviderHTTPS(r))
+
+  try {
+    const account = await client.createAccount({
+      termsOfServiceAgreed: true,
+      contact: ['mailto:test@example.com'],
+    })
+    return r.return(200, JSON.stringify(account))
+  } catch (e) {
+    const errMsg = `Error creating ACME account. Error=${e}`
+    log.error(errMsg)
+    return r.return(500, errMsg)
+  }
+}
+
+/**
+ * Create a new certificate Signing Request - Example implementation
+ * @param r
+ * @returns
+ */
+async function createCsrHandler(r: NginxHTTPRequest): Promise<void> {
+  const { pkcs10Ber, keys } = await createCsr({
+    // EXAMPLE VALUES BELOW
+    altNames: ['proxy1.f5.com', 'proxy2.f5.com'],
+    commonName: 'proxy.f5.com',
+    state: 'WA',
+    country: 'US',
+    organizationUnit: 'NGINX',
+  })
+  const privkey = (await crypto.subtle.exportKey(
+    'pkcs8',
+    keys.privateKey
+  )) as ArrayBuffer
+  const pubkey = (await crypto.subtle.exportKey(
+    'spki',
+    keys.publicKey
+  )) as ArrayBuffer
+  const privkeyPem = toPEM(privkey, 'PRIVATE KEY')
+  const pubkeyPem = toPEM(pubkey, 'PUBLIC KEY')
+  const csrPem = toPEM(pkcs10Ber, 'CERTIFICATE REQUEST')
+  const result = `${privkeyPem}\n${pubkeyPem}\n${csrPem}`
+  return r.return(200, result)
+}
+
+export default {
+  acmeNewAccount,
+  clientNewAccount,
+  createCsrHandler,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ async function clientNewAccount(r: NginxHTTPRequest): Promise<void> {
   } catch (e) {
     const errMsg = `Error creating ACME account. Error=${e}`
     log.error(errMsg)
-    return null; //r.return(500, errMsg)
+    return null
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,9 @@ const log = new Logger()
 async function clientAutoMode(r: NginxPeriodicSession): Promise<boolean> {
   const result = await clientAutoModeInternal(r)
   if (!result.success) {
-    log.error(`clientAutoModeInternal returned an error: ${JSON.stringify(result.info)}`)
+    log.error(
+      `clientAutoModeInternal returned an error: ${JSON.stringify(result.info)}`
+    )
   }
   return result.success
 }
@@ -54,7 +56,11 @@ async function clientAutoModeWeb(r: NginxHTTPRequest): Promise<void> {
   try {
     const result = await clientAutoModeInternal(r)
     if (!result.success) {
-      log.error(`clientAutoModeInternal returned an error: ${JSON.stringify(result.info)}`)
+      log.error(
+        `clientAutoModeInternal returned an error: ${JSON.stringify(
+          result.info
+        )}`
+      )
     }
     return r.return(result.success ? 200 : 500, JSON.stringify(result.info))
   } catch (e) {
@@ -89,7 +95,8 @@ async function clientAutoModeInternal(
   try {
     email = getVariable(r, 'njs_acme_account_email')
   } catch {
-    retVal.info.error = "Nginx variable '$njs_acme_account_email' or 'NJS_ACME_ACCOUNT_EMAIL' environment variable must be set"
+    retVal.info.error =
+      "Nginx variable '$njs_acme_account_email' or 'NJS_ACME_ACCOUNT_EMAIL' environment variable must be set"
     return retVal
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import {
   acmeAccountPrivateJWKPath,
   acmeAltNames,
   acmeChallengeDir,
-  acmeClientAutoModeURL,
   acmeCommonName,
   acmeDir,
   acmeDirectoryURI,
@@ -376,15 +375,6 @@ async function challengeResponse(r: NginxHTTPRequest): Promise<void> {
   }
 }
 
-/*
- * Handler for the `js_periodic` directive that requests /acme/auto periodically
- * to validate the stored certitificates.
- */
-async function periodicAuto(): Promise<void> {
-  // make the /acme/auto request to localhost
-  await ngx.fetch(acmeClientAutoModeURL())
-}
-
 export default {
   js_cert,
   js_key,
@@ -395,5 +385,4 @@ export default {
   createCsrHandler,
   LogLevel,
   Logger,
-  periodicAuto,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ import {
   generateKey,
   getVariable,
   joinPaths,
-  NginxPeriodicSession,
   readCertificateInfo,
   readOrCreateAccountKey,
   toPEM,
@@ -49,10 +48,10 @@ type clientAutoModeReturnType = {
  *  Method to use if you want to be able to trigger a certificate refresh from an HTTP request.
  *
  *
- * @param {NginxPeriodicSession | NginxHTTPRequest} r Incoming session or request
+ * @param {NginxHTTPRequest} r Incoming session or request
  * @returns void
  */
-async function clientAutoModeWeb(r: NginxHTTPRequest): Promise<void> {
+async function clientAutoModeHTTP(r: NginxHTTPRequest): Promise<void> {
   try {
     const result = await clientAutoModeInternal(r)
     if (!result.success) {
@@ -184,7 +183,7 @@ async function clientAutoModeInternal(
       csr: Buffer.from(csr.pkcs10Ber),
       email,
       termsOfServiceAgreed: true,
-      challengeCreateFn: async (authz, challenge, keyAuthorization) => {
+      challengeCreateFn: async (_, challenge, keyAuthorization) => {
         log.info(
           `Writing challenge file so nginx can serve it via .well-known/acme-challenge/${challenge.token}`
         )
@@ -425,7 +424,7 @@ export default {
   acmeNewAccount,
   challengeResponse,
   clientNewAccount,
-  clientAutoModeWeb,
+  clientAutoModeHTTP,
   clientAutoMode,
   createCsrHandler,
   LogLevel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   generateKey,
   getVariable,
   joinPaths,
+  NginxPeriodicSession,
   readCertificateInfo,
   readOrCreateAccountKey,
   toPEM,
@@ -35,7 +36,7 @@ const log = new Logger()
  * @param {NginxHTTPRequest} r Incoming request
  * @returns void
  */
-async function clientAutoMode(r: NginxHTTPRequest): Promise<boolean> {
+async function clientAutoMode(r: NginxPeriodicSession): Promise<boolean> {
   const log = new Logger('auto')
   const prefix = acmeDir(r)
   const commonName = acmeCommonName(r)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {
   acmeAccountPrivateJWKPath,
   acmeAltNames,
   acmeChallengeDir,
+  acmeClientAutoModeURL,
   acmeCommonName,
   acmeDir,
   acmeDirectoryURI,
@@ -382,7 +383,7 @@ async function periodicAuto(): Promise<void> {
   }
 
   // make the /acme/auto request to localhost
-  await ngx.fetch('http://localhost/acme/auto')
+  await ngx.fetch(acmeClientAutoModeURL())
 }
 
 export default {

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,11 +377,6 @@ async function challengeResponse(r: NginxHTTPRequest): Promise<void> {
  * to validate the stored certitificates.
  */
 async function periodicAuto(): Promise<void> {
-  // TODO should not need this in the final njs-0.8.1 release
-  if (ngx.worker_id !== 0) {
-    return
-  }
-
   // make the /acme/auto request to localhost
   await ngx.fetch(acmeClientAutoModeURL())
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,28 +8,6 @@ import { Logger } from './logger'
 
 const log = new Logger('utils')
 
-/**
- * TODO DELETE THIS ONCE njs-0.8.1 is released (0.8.1 defines this interface)
- * NginxPeriodicSession object is available as the first argument in the js_periodic handler.
- * @since 0.8.1
- */
-export interface NginxPeriodicSession {
-  /**
-   * nginx variables as Buffers.
-   *
-   * @see variables
-   */
-  readonly rawVariables: NginxRawVariables
-  /**
-   * nginx variables as strings.
-   *
-   * **Warning:** Bytes invalid in UTF-8 encoding may be converted into the replacement character.
-   *
-   * @see rawVariables
-   */
-  readonly variables: NginxVariables
-}
-
 // workaround for PKI.JS to work
 globalThis.unescape = querystring.unescape
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -852,7 +852,8 @@ export function acmeServerNames(r: NginxHTTPRequest): string[] {
  */
 export function acmeClientAutoModeURL(): string {
   return (
-    process.env.ACME_CLIENT_AUTO_MODE_URL || 'http://localhost:10999/acme/auto'
+    process.env.NJS_ACME_CLIENT_AUTO_MODE_URL ||
+    'http://localhost:10999/acme/auto'
   )
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,6 +44,10 @@ const ACCOUNT_KEY_ALG_IMPORT: RsaHashedImportParams = {
   hash: 'SHA-256',
 }
 
+export const KEY_SUFFIX = '.key'
+export const CERTIFICATE_SUFFIX = '.crt'
+export const CERTIFICATE_REQ_SUFFIX = '.csr'
+
 /**
  * Generates RSA private and public key pair
  * @returns {CryptoKeyPair} a private and public key pair
@@ -963,4 +967,68 @@ export function isValidHostname(hostname: string): boolean {
       /^[a-z\d]([-a-z\d]{0,61}[a-z\d])?(\.[a-z\d]([-a-z\d]{0,61}[a-z\d])?)*\.?$/i
     )
   )
+}
+
+/**
+ * Return the certificate
+ * @param {NginxHTTPRequest} r - The Nginx HTTP request object.
+ * @returns {string} - The contents of the cert or key
+ */
+export function readCert(r: NginxHTTPRequest): string {
+  return readCertOrKey(r, CERTIFICATE_SUFFIX)
+}
+
+/**
+ * Return the certificate
+ * @param {NginxHTTPRequest} r - The Nginx HTTP request object.
+ * @returns {string} - The contents of the cert or key
+ */
+export function readKey(r: NginxHTTPRequest): string {
+  return readCertOrKey(r, KEY_SUFFIX)
+}
+
+/**
+ * Given a request and suffix that indicates whether the caller wants the cert
+ * or key, return the requested object from cache if possible, falling back to
+ * disk.
+ * @param {NginxHTTPRequest} r - The Nginx HTTP request object.
+ * @param {string} suffix - The file suffix that indicates whether we want a cert or key
+ * @returns {string} - The contents of the cert or key
+ */
+function readCertOrKey(
+  r: NginxHTTPRequest,
+  suffix: typeof CERTIFICATE_SUFFIX | typeof KEY_SUFFIX
+): string {
+  let data = ''
+  const prefix = acmeDir(r)
+  const commonName = acmeCommonName(r)
+  const zone = acmeZoneName(r)
+  const path = joinPaths(prefix, commonName + suffix)
+  const key = ['acme', path].join(':')
+
+  // if the zone is not defined in nginx.conf, then we will bypass the cache
+  const cache = zone && ngx.shared && ngx.shared[zone]
+
+  if (cache) {
+    data = (cache.get(key) as string) || ''
+    if (data) {
+      return data
+    }
+  }
+  try {
+    data = fs.readFileSync(path, 'utf8')
+  } catch (e) {
+    log.error('error reading from file:', path, `. Error=${e}`)
+    return ''
+  }
+  if (cache && data) {
+    try {
+      cache.set(key, data)
+      log.debug(`wrote to cache: ${key} zone: ${zone}`)
+    } catch (e) {
+      const errMsg = `error writing to shared dict zone: ${zone}. Error=${e}`
+      log.error(errMsg)
+    }
+  }
+  return data
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -847,17 +847,6 @@ export function acmeServerNames(r: NginxHTTPRequest): string[] {
 }
 
 /**
- * Return a URL to use to fetch the clientAutoMode endpoint
- * @returns clientAutoModeURL
- */
-export function acmeClientAutoModeURL(): string {
-  return (
-    process.env.NJS_ACME_CLIENT_AUTO_MODE_URL ||
-    'http://localhost:10999/acme/auto'
-  )
-}
-
-/**
  * Return the path where ACME magic happens
  * @param r request
  * @returns configured path or default

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,28 @@ import { Logger } from './logger'
 
 const log = new Logger('utils')
 
+/**
+ * TODO DELETE THIS ONCE njs-0.8.1 is released (0.8.1 defines this interface)
+ * NginxPeriodicSession object is available as the first argument in the js_periodic handler.
+ * @since 0.8.1
+ */
+export interface NginxPeriodicSession {
+  /**
+   * nginx variables as Buffers.
+   *
+   * @see variables
+   */
+  readonly rawVariables: NginxRawVariables
+  /**
+   * nginx variables as strings.
+   *
+   * **Warning:** Bytes invalid in UTF-8 encoding may be converted into the replacement character.
+   *
+   * @see rawVariables
+   */
+  readonly variables: NginxVariables
+}
+
 // workaround for PKI.JS to work
 globalThis.unescape = querystring.unescape
 
@@ -778,7 +800,7 @@ export function readX509ServerNames(certPem: string | Buffer): CertDomains {
  * @returns value of the variable
  */
 export function getVariable(
-  r: NginxHTTPRequest,
+  r: NginxHTTPRequest | NginxPeriodicSession,
   varname:
     | 'njs_acme_account_email'
     | 'njs_acme_server_names'
@@ -805,7 +827,9 @@ export function getVariable(
  * @param r request
  * @returns {string} hostname
  */
-export function acmeCommonName(r: NginxHTTPRequest): string {
+export function acmeCommonName(
+  r: NginxHTTPRequest | NginxPeriodicSession
+): string {
   // The first name is the common name
   return acmeServerNames(r)[0]
 }
@@ -815,7 +839,9 @@ export function acmeCommonName(r: NginxHTTPRequest): string {
  * @param r request
  * @returns {string} hostname
  */
-export function acmeAltNames(r: NginxHTTPRequest): string[] {
+export function acmeAltNames(
+  r: NginxHTTPRequest | NginxPeriodicSession
+): string[] {
   const serverNames = acmeServerNames(r)
   if (serverNames.length <= 1) {
     // no alt names
@@ -830,7 +856,9 @@ export function acmeAltNames(r: NginxHTTPRequest): string[] {
  * @param r request
  * @returns array of hostnames
  */
-export function acmeServerNames(r: NginxHTTPRequest): string[] {
+export function acmeServerNames(
+  r: NginxHTTPRequest | NginxPeriodicSession
+): string[] {
   const nameStr = getVariable(r, 'njs_acme_server_names') // no default == mandatory
   // split string value on comma and/or whitespace and lowercase each element
   const names = nameStr.split(/[,\s]+/)
@@ -851,7 +879,7 @@ export function acmeServerNames(r: NginxHTTPRequest): string[] {
  * @param r request
  * @returns configured path or default
  */
-export function acmeDir(r: NginxHTTPRequest): string {
+export function acmeDir(r: NginxHTTPRequest | NginxPeriodicSession): string {
   return getVariable(r, 'njs_acme_dir', '/etc/nginx/njs-acme')
 }
 
@@ -860,7 +888,9 @@ export function acmeDir(r: NginxHTTPRequest): string {
  * @param r request
  * @returns configured shared_dict zone name or default
  */
-export function acmeZoneName(r: NginxHTTPRequest): string {
+export function acmeZoneName(
+  r: NginxHTTPRequest | NginxPeriodicSession
+): string {
   return getVariable(r, 'njs_acme_shared_dict_zone_name', 'acme')
 }
 /**
@@ -868,7 +898,9 @@ export function acmeZoneName(r: NginxHTTPRequest): string {
  * @param r request
  * @returns configured path or default
  */
-export function acmeChallengeDir(r: NginxHTTPRequest): string {
+export function acmeChallengeDir(
+  r: NginxHTTPRequest | NginxPeriodicSession
+): string {
   return getVariable(
     r,
     'njs_acme_challenge_dir',
@@ -878,9 +910,11 @@ export function acmeChallengeDir(r: NginxHTTPRequest): string {
 
 /**
  * Returns the path for the account private JWK
- * @param r {NginxHTTPRequest}
+ * @param r {NginxHTTPRequest | NginxPeriodicSession}
  */
-export function acmeAccountPrivateJWKPath(r: NginxHTTPRequest): string {
+export function acmeAccountPrivateJWKPath(
+  r: NginxHTTPRequest | NginxPeriodicSession
+): string {
   return getVariable(
     r,
     'njs_acme_account_private_jwk',
@@ -890,9 +924,11 @@ export function acmeAccountPrivateJWKPath(r: NginxHTTPRequest): string {
 
 /**
  * Returns the ACME directory URI
- * @param r {NginxHTTPRequest}
+ * @param r {NginxHTTPRequest | NginxPeriodicSession}
  */
-export function acmeDirectoryURI(r: NginxHTTPRequest): string {
+export function acmeDirectoryURI(
+  r: NginxHTTPRequest | NginxPeriodicSession
+): string {
   return getVariable(
     r,
     'njs_acme_directory_uri',
@@ -902,10 +938,12 @@ export function acmeDirectoryURI(r: NginxHTTPRequest): string {
 
 /**
  * Returns whether to verify the ACME provider HTTPS certificate and chain
- * @param r {NginxHTTPRequest}
+ * @param r {NginxHTTPRequest | NginxPeriodicSession}
  * @returns boolean
  */
-export function acmeVerifyProviderHTTPS(r: NginxHTTPRequest): boolean {
+export function acmeVerifyProviderHTTPS(
+  r: NginxHTTPRequest | NginxPeriodicSession
+): boolean {
   return (
     ['true', 'yes', '1'].indexOf(
       getVariable(r, 'njs_acme_verify_provider_https', 'true')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -847,6 +847,16 @@ export function acmeServerNames(r: NginxHTTPRequest): string[] {
 }
 
 /**
+ * Return a URL to use to fetch the clientAutoMode endpoint
+ * @returns clientAutoModeURL
+ */
+export function acmeClientAutoModeURL(): string {
+  return (
+    process.env.ACME_CLIENT_AUTO_MODE_URL || 'http://localhost:10999/acme/auto'
+  )
+}
+
+/**
  * Return the path where ACME magic happens
  * @param r request
  * @returns configured path or default


### PR DESCRIPTION
Uses the new directive `js_periodic` in njs >= 0.8.2 to invoke `clientAutoMode(r)` on regular intervals. This eliminates the need to set up a cron or use docker healthchecks.

### Proposed changes

* Use `js_periodic` to invoke `clientAutoMode()` periodically.
* Clarify some instructions for variable use in the shared dict zone.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/njs-acme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/njs-acme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/njs-acme/blob/main/CHANGELOG.md))
