### PR TITLE
fixes #50 - purge cached cert/key when a replacement is received

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   KEY_SUFFIX,
   CERTIFICATE_SUFFIX,
   CERTIFICATE_REQ_SUFFIX,
+  purgeCachedCertKey,
 } from './utils'
 import { AcmeClient } from './client'
 import fs from 'fs'
@@ -203,6 +204,9 @@ async function clientAutoModeInternal(
     certInfo = await readCertificateInfo(certificatePem)
     fs.writeFileSync(certPath, certificatePem)
     log.info(`Wrote certificate to ${certPath}`)
+
+    // Purge the cert/key in the shared dict zone if applicable
+    purgeCachedCertKey(r)
   }
 
   retVal.success = true


### PR DESCRIPTION
### Proposed changes

Fixes Issue #50 - Purge cached cert/key from shared dictionary zone (if applicable) when we receive a replacement. This allows for on-the-fly certificate reconfiguration (e.g. adding a domain) by using `nginx -s reload`.

Thank you @NetForce1 for raising the issue and your clarity in describing the symptoms and repro case.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/njs-acme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/njs-acme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/njs-acme/blob/main/CHANGELOG.md))

#### Confirmation of fix
Before: 2 hosts in certificate
![Screenshot 2024-03-22 at 1 34 53 PM](https://github.com/nginx/njs-acme/assets/8418898/793b1e35-8383-427c-a0cb-042cd0d4fd2f)

Reload nginx (via `docker compose exec nginx bash`)
![Screenshot 2024-03-22 at 1 37 35 PM](https://github.com/nginx/njs-acme/assets/8418898/6a687176-078d-4b48-b983-4407b58e5ab3)

```
nginx-1   | 2024/03/22 20:34:35 [info] 24#24: js: njs-acme: [auto] Renewing certificate because the hostnames in the certificate (proxy.nginx.com, proxy2.nginx.com) do not match the configured njs_acme_server_names (proxy.nginx.com)
```

After: 1 host in certificate
![Screenshot 2024-03-22 at 1 35 37 PM](https://github.com/nginx/njs-acme/assets/8418898/d0656ab0-12ac-4540-8200-f56cd8abfc1c)
