### PR TITLE
Fixes #52 - Ensure key/cert are in a consistent state despite errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 1.0.0 (Month Date, Year)
+## 1.0.0 (March 25, 2024)
 
-Initial release of the NGINX template repository.
+Initial release of njs-acme.

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ async function clientAutoModeInternal(
   }
 
   const pkeyPath = joinPaths(prefix, commonName + KEY_SUFFIX)
+  const tempPkeyPath = pkeyPath + '.tmp'
   const csrPath = joinPaths(prefix, commonName + CERTIFICATE_REQ_SUFFIX)
   const certPath = joinPaths(prefix, commonName + CERTIFICATE_SUFFIX)
 
@@ -168,8 +169,8 @@ async function clientAutoModeInternal(
       csr.keys.privateKey
     )) as ArrayBuffer
     pkeyPem = toPEM(privKey, 'PRIVATE KEY')
-    fs.writeFileSync(pkeyPath, pkeyPem)
-    log.info(`Wrote private key to ${pkeyPath}`)
+    fs.writeFileSync(tempPkeyPath, pkeyPem)
+    log.info(`Wrote private key to ${tempPkeyPath}`)
 
     const challengePath = acmeChallengeDir(r)
 
@@ -204,6 +205,8 @@ async function clientAutoModeInternal(
     certInfo = await readCertificateInfo(certificatePem)
     fs.writeFileSync(certPath, certificatePem)
     log.info(`Wrote certificate to ${certPath}`)
+    fs.renameSync(tempPkeyPath, pkeyPath)
+    log.info(`Renamed ${tempPkeyPath} to ${pkeyPath}`)
 
     // Purge the cert/key in the shared dict zone if applicable
     purgeCachedCertKey(r)


### PR DESCRIPTION
### Proposed changes

Issue #52 details a scenario where a failure during ACME validation can leave the target system in a failed state where HTTPS does not work at all. The nature of the problem is that the new .key file is written before the ACME validation step runs. If that validation fails, then the system is left with a new `.key` file and an old `.crt` file, which is invalid.

This change is to first write the new `.key` to a `.key.tmp` file, do the ACME validation, store the `.crt`, then rename the `.key.tmp` file to `.key` before purging the cache.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/njs-acme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginx/njs-acme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginx/njs-acme/blob/main/CHANGELOG.md))
